### PR TITLE
Install haskell-ide-engine as per its README.md

### DIFF
--- a/theia-haskell-docker/Dockerfile
+++ b/theia-haskell-docker/Dockerfile
@@ -5,7 +5,8 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 
 RUN git clone https://github.com/haskell/haskell-ide-engine --recursive --depth 1 && \
     cd haskell-ide-engine && \
-    stack install
+    stack ./install.hs hie-8.6.5 && \
+    stack ./install.hs build-doc
 
 ARG version=latest
 


### PR DESCRIPTION
Note that `build-doc` is mandatory, it's not only doc, but many features of HIE rely on the hoogle database.

Closes https://github.com/haskell/haskell-ide-engine/issues/1244